### PR TITLE
Add a return at dialog method. Then developers will be able to remove…

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -3414,7 +3414,7 @@ const _focus = async selector => {
 
 const dialog = (dialogType, dialogMessage, callback) => {
   validate();
-  eventHandler.once(
+  return eventHandler.once(
     createJsDialogEventName(dialogMessage, dialogType),
     async ({ message }) => {
       if (dialogMessage === message) await callback();


### PR DESCRIPTION
… nonused listeners and avoid memory leak